### PR TITLE
Add YAML load test for prometheus config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# ModulCloud
+
+This repository contains configuration files for Prometheus, Grafana, and related services.
+
+## Running Tests
+
+Install dependencies:
+
+```bash
+pip install pytest pyyaml
+```
+
+Run the tests with:
+
+```bash
+pytest
+```
+

--- a/tests/test_prometheus_config.py
+++ b/tests/test_prometheus_config.py
@@ -1,0 +1,10 @@
+import yaml
+import os
+
+
+def test_prometheus_yaml_loads():
+    config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'prometheus.yml')
+    with open(config_path, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    assert data is not None
+


### PR DESCRIPTION
## Summary
- add pytest that loads `prometheus.yml`
- document how to run the tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68415d2d9fb083339f480a701ecadbd0