### PR TITLE
Fix grammar in node exporter tasks

### DIFF
--- a/Ansible_Files/main_tasks_node.yaml
+++ b/Ansible_Files/main_tasks_node.yaml
@@ -1,6 +1,6 @@
 ---
 # tasks file for roles/node-exporter
-- name: check if node exporter exist
+- name: check if node exporter exists
   stat:
     path: "{{ node_exporter_bin }}"
   register: __check_node_exporter_present


### PR DESCRIPTION
## Summary
- update node exporter task description to "check if node exporter exists"

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68415d2c87e08333b21832213114e02c