### PR TITLE
Fix gpg key description

### DIFF
--- a/Ansible_Files/main_tasks_grafana.yaml
+++ b/Ansible_Files/main_tasks_grafana.yaml
@@ -6,7 +6,7 @@
     state: present
     update_cache: yes
     cache_valid_time: 3600
-- name: add gpg hey
+- name: add gpg key
   apt_key:
     url: "https://packages.grafana.com/gpg.key"
     validate_certs: no


### PR DESCRIPTION
## Summary
- fix typo in Grafana tasks

## Testing
- `ansible-lint --version` *(fails: command not found)*
- `ansible-playbook --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415d2a1c1483338e034a5ea544b64d