### PR TITLE
Add Docker update web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ Run the tests with:
 pytest
 ```
 
+
+## Docker Update Web Interface
+
+A simple Flask application is provided in `docker_update_webapp.py`. It lists running Docker containers, checks whether their images are up to date and, if not, allows updating them.
+
+Install additional dependencies:
+
+```bash
+pip install flask docker
+```
+
+Run the web interface with:
+
+```bash
+python docker_update_webapp.py
+```
+
+The application will start on port 5000.

--- a/docker_update_webapp.py
+++ b/docker_update_webapp.py
@@ -1,0 +1,77 @@
+import docker
+from flask import Flask, render_template_string, redirect, url_for
+
+app = Flask(__name__)
+client = docker.from_env()
+
+TEMPLATE = """
+<!doctype html>
+<html>
+<head>
+    <title>Docker Update Checker</title>
+    <style>
+        table { border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 8px; }
+        th { background-color: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <h1>Docker Containers</h1>
+    <table>
+        <tr><th>Name</th><th>Image</th><th>Status</th><th>Action</th></tr>
+        {% for c in containers %}
+        <tr>
+            <td>{{ c.name }}</td>
+            <td>{{ c.image }}</td>
+            <td>{% if c.up_to_date %}Up to date{% else %}Update available{% endif %}</td>
+            <td>
+                {% if not c.up_to_date %}
+                <form action="{{ url_for('update_container', cid=c.id) }}" method="post">
+                    <button type="submit">Update</button>
+                </form>
+                {% else %}-{% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>
+"""
+
+
+def image_up_to_date(container):
+    tags = container.image.tags
+    if not tags:
+        return True
+    tag = tags[0]
+    pulled = client.images.pull(tag)
+    return pulled.id == container.image.id
+
+
+@app.route('/')
+def index():
+    containers = []
+    for c in client.containers.list(all=True):
+        containers.append({
+            'id': c.id,
+            'name': c.name,
+            'image': c.image.tags[0] if c.image.tags else c.image.short_id,
+            'up_to_date': image_up_to_date(c)
+        })
+    return render_template_string(TEMPLATE, containers=containers)
+
+
+@app.route('/update/<cid>', methods=['POST'])
+def update_container(cid):
+    container = client.containers.get(cid)
+    if container.image.tags:
+        tag = container.image.tags[0]
+        client.images.pull(tag)
+        container.stop()
+        container.remove()
+        client.containers.run(tag, detach=True, name=container.name)
+    return redirect(url_for('index'))
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/tests/test_webapp_import.py
+++ b/tests/test_webapp_import.py
@@ -1,0 +1,4 @@
+import importlib
+
+def test_webapp_imports():
+    assert importlib.import_module('docker_update_webapp') is not None


### PR DESCRIPTION
## Summary
- add Flask-based tool `docker_update_webapp.py` to check containers and update them
- document how to run the tool in README
- test the module can be imported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6841613dcfa48333891ae3b11066ccd8